### PR TITLE
Expose line no. information for each statement     

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: Build & test
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,12 +68,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,29 +104,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bindgen"
-version = "0.66.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
- "which",
-]
 
 [[package]]
 name = "bitflags"
@@ -186,30 +148,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
 
 [[package]]
 name = "clap"
@@ -306,38 +248,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -422,12 +336,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
 name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,15 +357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,24 +371,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -508,44 +389,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
-
-[[package]]
-name = "libloading"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-dependencies = [
- "cfg-if",
- "windows-targets",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -580,12 +427,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,22 +444,6 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "multimap"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -670,44 +495,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "petgraph"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
-name = "pg_query"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71c7c56dfe299ec6f98aa210aa23458be3b0610c485be60a5873c2f3627c40e"
-dependencies = [
- "bindgen",
- "cc",
- "fs_extra",
- "glob",
- "itertools 0.10.5",
- "prost",
- "prost-build",
- "serde",
- "serde_json",
- "thiserror",
-]
 
 [[package]]
 name = "pglockanalyze"
@@ -715,12 +506,12 @@ version = "0.0.2"
 dependencies = [
  "clap",
  "patharg",
- "pg_query",
  "postgres",
  "pretty_assertions",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sqlparser",
 ]
 
 [[package]]
@@ -816,16 +607,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,55 +616,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.13.5"
+name = "psm"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
-dependencies = [
- "heck",
- "itertools 0.14.0",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn",
- "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
-dependencies = [
- "prost",
+ "cc",
 ]
 
 [[package]]
@@ -931,6 +669,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "recursive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,71 +698,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "ryu"
@@ -1112,6 +809,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlparser"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68feb51ffa54fc841e086f58da543facfe3d7ae2a60d69b0a8cbbd30d16ae8d"
+dependencies = [
+ "log",
+ "recursive",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,39 +863,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
-dependencies = [
- "fastrand",
- "getrandom",
- "once_cell",
- "rustix 1.0.7",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1384,18 +1071,6 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["database", "command-line-utilities"]
 [dependencies]
 clap = { version = "4.5.37", features = ["derive"] }
 patharg = "0.4.0"
-pg_query = "6.0.0"
 postgres = { version = "0.19.10"}
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+sqlparser = "0.56.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,10 @@
+use sqlparser::parser::ParserError;
 use std::fmt;
 
 #[derive(Debug)]
 pub enum Error {
     InputError(std::io::Error),
-    AnalyzeError(pg_query::Error),
+    AnalyzeError(ParserError),
     ConfigParseError(postgres::Error),
     ConfigOtherError(String),
 }
@@ -20,8 +21,8 @@ impl From<&str> for Error {
     }
 }
 
-impl From<pg_query::Error> for Error {
-    fn from(e: pg_query::Error) -> Error {
+impl From<ParserError> for Error {
+    fn from(e: ParserError) -> Error {
         Error::AnalyzeError(e)
     }
 }

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -2,23 +2,43 @@ use crate::errors::Error;
 use crate::lock::{Lock, Locks};
 use postgres as pg;
 use serde::{Deserialize, Serialize};
+use sqlparser::ast::Spanned;
+use sqlparser::ast::Statement as AstStatement;
 use std::collections::HashSet;
 use std::fmt;
+
+/// Starting and ending lines in the original input where a statement appears
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct Location {
+    pub start_line: u64,
+    pub end_line: u64,
+}
+
+impl From<sqlparser::tokenizer::Span> for Location {
+    fn from(span: sqlparser::tokenizer::Span) -> Self {
+        Self {
+            start_line: span.start.line,
+            end_line: span.end.line,
+        }
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Statement {
     pub sql: String,
     pub locks_acquired: Locks,
+    pub location: Location,
 }
 
 impl Statement {
     pub fn analyze(
         db: &pg::Config,
-        sql: String,
         tx: &mut pg::Transaction,
         pid: i32,
+        stmt: AstStatement,
     ) -> Result<Self, Error> {
         let locks_before = Self::detect_locks(db, pid)?;
+        let sql = stmt.to_string();
         tx.execute(&sql, &[])?;
         let locks_after = Self::detect_locks(db, pid)?;
         let locks_acquired = Locks::compute_acquired(locks_before, locks_after);
@@ -26,6 +46,7 @@ impl Statement {
         Ok(Statement {
             sql,
             locks_acquired,
+            location: stmt.span().into(),
         })
     }
 

--- a/tests/fixture.yml
+++ b/tests/fixture.yml
@@ -1,4 +1,4 @@
-- starting_schema: |-
+- initial_schema: |-
     CREATE TABLE users (
       id serial PRIMARY KEY,
       foo text
@@ -6,7 +6,10 @@
   statements: |-
     ALTER TABLE users ADD COLUMN email text;
   expected:
-    - sql: ALTER TABLE users ADD COLUMN email text
+    - sql: ALTER TABLE users ADD COLUMN email TEXT
+      location:
+        start_line: 1
+        end_line: 1
       locks_acquired:
         - database:
             name: pglatests
@@ -14,7 +17,7 @@
           lock_target: !relation
             alias: users
 
-- starting_schema: |-
+- initial_schema: |-
     CREATE TABLE products (
       id serial PRIMARY KEY,
       price numeric
@@ -23,6 +26,9 @@
     ALTER TABLE products RENAME COLUMN price TO cost;
   expected:
     - sql: ALTER TABLE products RENAME COLUMN price TO cost
+      location:
+        start_line: 1
+        end_line: 1
       locks_acquired:
         - database:
             name: pglatests
@@ -30,7 +36,7 @@
           lock_target: !relation
             alias: products
 
-- starting_schema: |-
+- initial_schema: |-
     CREATE TABLE orders (
       id serial PRIMARY KEY
     );
@@ -38,6 +44,9 @@
     ALTER TABLE orders RENAME TO orders_archive;
   expected:
     - sql: ALTER TABLE orders RENAME TO orders_archive
+      location:
+        start_line: 1
+        end_line: 1
       locks_acquired:
         - database:
             name: pglatests
@@ -47,7 +56,7 @@
             # rename (otherwise this would be orders_archive)
             alias: orders
 
-- starting_schema: |-
+- initial_schema: |-
     CREATE TABLE customers (
       id    serial PRIMARY KEY,
       email text
@@ -57,6 +66,9 @@
     ALTER TABLE customers RENAME COLUMN email TO contact_email;
   expected:
     - sql: ALTER TABLE customers ALTER COLUMN email SET NOT NULL
+      location:
+        start_line: 1
+        end_line: 1
       locks_acquired:
         - database:
             name: pglatests
@@ -64,18 +76,24 @@
           lock_target: !relation
             alias: customers
     - sql: ALTER TABLE customers RENAME COLUMN email TO contact_email
+      location:
+        start_line: 2
+        end_line: 2
       locks_acquired: []
 
-- starting_schema: |-
+- initial_schema: |-
     CREATE TABLE logs (
       id      serial PRIMARY KEY,
       message text,
       details text
     );
   statements: |-
-    ALTER TABLE logs DROP details;
+    ALTER TABLE logs DROP COLUMN details;
   expected:
-    - sql: ALTER TABLE logs DROP details
+    - sql: ALTER TABLE logs DROP COLUMN details
+      location:
+        start_line: 1
+        end_line: 1
       locks_acquired:
         - database:
             name: pglatests
@@ -83,7 +101,7 @@
           lock_target: !relation
             alias: logs
 
-- starting_schema: |-
+- initial_schema: |-
     CREATE TABLE audits (
       id     serial PRIMARY KEY,
       amount numeric
@@ -93,6 +111,9 @@
     ALTER TABLE audits RENAME TO audit_logs;
   expected:
     - sql: ALTER TABLE audits ADD CHECK (amount >= 0)
+      location:
+        start_line: 1
+        end_line: 1
       locks_acquired:
         - database:
             name: pglatests
@@ -100,4 +121,7 @@
           lock_target: !relation
             alias: audits
     - sql: ALTER TABLE audits RENAME TO audit_logs
+      location:
+        start_line: 2
+        end_line: 2
       locks_acquired: []

--- a/tests/fixture_locations.yml
+++ b/tests/fixture_locations.yml
@@ -1,0 +1,73 @@
+- initial_schema: |-
+    CREATE TABLE frogs (
+      id serial PRIMARY KEY
+    );
+  statements: |-
+      -- hi
+      ALTER TABLE frogs
+      ADD COLUMN
+      email INT;
+
+      -- foo
+      ALTER TABLE frogs
+      ADD COLUMN
+      name INT;
+
+
+      ALTER TABLE frogs ADD COLUMN e INT; ALTER TABLE frogs ADD COLUMN d INT;
+      SELECT 1;
+
+      SELECT
+      2;
+      --
+  expected:
+    - sql: ALTER TABLE frogs ADD COLUMN email INT
+      location:
+        start_line: 2
+        end_line: 4
+      locks_acquired:
+        - database:
+            name: pglatests
+          mode: AccessExclusive
+          lock_target: !relation
+            alias: frogs
+    - sql: ALTER TABLE frogs ADD COLUMN name INT
+      location:
+        start_line: 7
+        end_line: 9
+      locks_acquired:
+        - database:
+            name: pglatests
+          mode: AccessExclusive
+          lock_target: !relation
+            alias: frogs
+    - sql: ALTER TABLE frogs ADD COLUMN e INT
+      location:
+        start_line: 12
+        end_line: 12
+      locks_acquired:
+        - database:
+            name: pglatests
+          mode: AccessExclusive
+          lock_target: !relation
+            alias: frogs
+    - sql: ALTER TABLE frogs ADD COLUMN d INT
+      location:
+        start_line: 12
+        end_line: 12
+      locks_acquired:
+        - database:
+            name: pglatests
+          mode: AccessExclusive
+          lock_target: !relation
+            alias: frogs
+    - sql: SELECT 1
+      location:
+        start_line: 13
+        end_line: 13
+      locks_acquired: []
+    - sql: SELECT 2
+      location:
+        start_line: 15
+        end_line: 16
+      locks_acquired: []

--- a/tests/fixture_non_wrapping.yml
+++ b/tests/fixture_non_wrapping.yml
@@ -1,20 +1,26 @@
-- starting_schema: |-
+- initial_schema: |-
     CREATE TABLE foobarz (
       id serial PRIMARY KEY,
       foo text
     );
   statements: |-
     ALTER TABLE foobarz ADD COLUMN email text;
-    ALTER TABLE foobarz DROP email;
+    ALTER TABLE foobarz DROP COLUMN email;
   expected:
-    - sql: ALTER TABLE foobarz ADD COLUMN email text
+    - sql: ALTER TABLE foobarz ADD COLUMN email TEXT
+      location:
+        start_line: 1
+        end_line: 1
       locks_acquired:
         - database:
             name: pglatests
           mode: AccessExclusive
           lock_target: !relation
             alias: foobarz
-    - sql: ALTER TABLE foobarz DROP email
+    - sql: ALTER TABLE foobarz DROP COLUMN email
+      location:
+        start_line: 2
+        end_line: 2
       locks_acquired:
         - database:
             name: pglatests


### PR DESCRIPTION
This patch adds support for storing the start/end line number for each statement present in the original input. The CLI only prints this information when the JSON formatter is used, as of now:

    [
      {
        "sql": "......",
        "locks_acquired": [],
        "location": {
          "start_line": 1,
          "end_line": 3
        }
    ]

To do this, we migrate from libpq_query to sqlparser, which expose line no. information. There's still a small bug reported upstream[1] but this is at least a good starting point.

Part of #17

[1] https://github.com/apache/datafusion-sqlparser-rs/issues/1858